### PR TITLE
Allow users to pass puppeteerOptions

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -15,12 +15,13 @@ async function renderGoogleChart(contentRaw, optsRaw) {
       packages: ['corechart'],
       mapsApiKey: '',
       width: '100%',
-      height: '100%',
+      height: '100%'
     },
     optsRaw || {},
   );
+  console.log("opts", opts)
 
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch(opts.puppeteerOptions);
 
   const page = await browser.newPage();
   page.setDefaultTimeout(RENDER_TIMEOUT_MS);

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,7 +19,6 @@ async function renderGoogleChart(contentRaw, optsRaw) {
     },
     optsRaw || {},
   );
-  console.log("opts", opts)
 
   const browser = await puppeteer.launch(opts.puppeteerOptions);
 


### PR DESCRIPTION
This is useful for applications that require other puppeteer settings to be able to use the project.

A practical example: applications built in electron, where it is not possible to use the puppeteer built-in executable, requiring the configuration of puppeteer.executablePath. The config would look like this:

```js
function drawChart() {
    // ...
}

const image = await GoogleChartsNode.render(drawChart, {
    width: 800,
    height: 600,
    puppeteerOptions: {
      executablePath: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
    }
})
```